### PR TITLE
Developer Guide: Fix macOS naming in Glossary

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -1000,7 +1000,7 @@ User interacts with the address book through graphical icons and visual indicato
 Mainstream OS
 
 ....
-Windows, Linux, Unix, OS-X
+Windows, Linux, Unix, macOS
 ....
 
 [[private-contact-detail]]


### PR DESCRIPTION
Fix incorrect naming of Macintosh operating system (OS X has been replaced since 2016)